### PR TITLE
Add Vite configuration for React with plugins

### DIFF
--- a/new vite.config.ts
+++ b/new vite.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, type Plugin } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const NODE_ENV_DEVELOPMENT = "development";
+const LOVABLE_TAGGER_MODULE = "lovable-tagger";
+
+/**
+ * Builds the Vite plugin list. The React plugin is always included.
+ * In development only, tries to add lovable-tagger if available; if missing or
+ * broken, the build continues without it so CI and forks are not blocked.
+ *
+ * @param mode - Vite env mode (e.g. "development" | "production")
+ * @returns Array of Vite plugins
+ */
+function getPlugins(mode: string | undefined): Plugin[] {
+  const plugins: Plugin[] = [react()];
+
+  const isDev = typeof mode === "string" && mode === NODE_ENV_DEVELOPMENT;
+  if (!isDev) {
+    return plugins;
+  }
+
+  try {
+    const taggerModule = require(LOVABLE_TAGGER_MODULE) as { componentTagger?: () => Plugin };
+    const componentTagger = taggerModule?.componentTagger;
+    if (typeof componentTagger === "function") {
+      plugins.push(componentTagger());
+    }
+  } catch {
+    // Optional: lovable-tagger not installed or failed to load; continue without it
+  }
+
+  return plugins;
+}
+
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => ({
+  server: {
+    host: "::",
+    port: 8080,
+  },
+  plugins: getPlugins(mode),
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+}));


### PR DESCRIPTION
VIBE Report
1. Target Selected: I want to fix  that the build depends on lovable-tagger.This is low risk because all you need to do is plugin change/removal breaks build until config is fixed.
2. The Verification Event: 
 AI’s suggestion - import { componentTagger } from "lovable-tagger";


export default defineConfig(({ mode }) => ({
  ...
  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
  ...
}));


My final implementation - import { createRequire } from "node:module";
const require = createRequire(import.meta.url);


function getPlugins(mode: string) {
  const plugins = [react()];
  if (mode === "development") {
    try {
      const { componentTagger } = require("lovable-tagger");
      plugins.push(componentTagger());
    } catch {
      // Optional: tagger not installed or failed to load; continue without it
    }
  }
  return plugins;
}


export default defineConfig(({ mode }) => ({
  ...
  plugins: getPlugins(mode),
  ...
}));


3. Trust Boundary Established: This refactor improves stability by removing a hard dependency on lovable-tagger from the build config. This ensures production builds never rely on it, makes the tagger optional, and prevents a third-party dev dependency from blocking local or CI workflows.
4. Evidence of Execution: 
<img width="1437" height="792" alt="Screenshot 2026-02-18 at 12 39 58 PM" src="https://github.com/user-attachments/assets/df6b686f-c283-4578-8e46-fe897f064569" />

