### PR TITLE
feat: content reporting, anonymity UX, filtered discussion, and post comments (F2.2, F2.3, F2.7)

### DIFF
--- a/src/components/forum/PostReportFlow.tsx
+++ b/src/components/forum/PostReportFlow.tsx
@@ -1,0 +1,237 @@
+import { useState } from "react";
+import { Flag, HeartHandshake, Loader2, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+type ReportReason =
+  | "inappropriate-language"
+  | "harassment"
+  | "spam"
+  | "crisis-content"
+  | "other";
+
+interface PostReportFlowProps {
+  postId: string;
+  postAuthor?: string;
+  onSubmitReport?: (payload: {
+    postId: string;
+    reason: ReportReason;
+    details?: string;
+  }) => Promise<void> | void;
+}
+
+const REPORT_REASONS: Array<{
+  value: ReportReason;
+  label: string;
+  helper: string;
+}> = [
+  {
+    value: "inappropriate-language",
+    label: "Inappropriate language",
+    helper: "Content feels hurtful or not supportive for this space.",
+  },
+  {
+    value: "harassment",
+    label: "Harassment or targeting",
+    helper: "A person or group appears to be singled out unfairly.",
+  },
+  {
+    value: "spam",
+    label: "Spam or repetitive posting",
+    helper: "Looks promotional or repeated in a way that disrupts discussion.",
+  },
+  {
+    value: "crisis-content",
+    label: "Possible crisis content",
+    helper: "May need extra care or urgent support resources.",
+  },
+  {
+    value: "other",
+    label: "Something else feels off",
+    helper: "Share context in your own words so moderators can review kindly.",
+  },
+];
+
+/**
+ * Standalone UI for post reporting.
+ * - Subtle trigger for low-pressure access.
+ * - Gentle reason selection and optional context.
+ * - Reassuring confirmation state after submit.
+ */
+export function PostReportFlow({
+  postId,
+  postAuthor,
+  onSubmitReport,
+}: PostReportFlowProps) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState<ReportReason | "">("");
+  const [details, setDetails] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const reset = () => {
+    setReason("");
+    setDetails("");
+    setSubmitting(false);
+    setSubmitted(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      reset();
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!reason) return;
+    setSubmitting(true);
+    try {
+      await onSubmitReport?.({
+        postId,
+        reason,
+        details: details.trim() || undefined,
+      });
+      setSubmitted(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Report post"
+        >
+          <Flag className="h-4 w-4" />
+          <span className="hidden sm:inline">Report</span>
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="rounded-2xl border-border/70 p-0 overflow-hidden">
+        {!submitted ? (
+          <>
+            <div className="bg-muted/40 p-6 border-b border-border/60">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2 text-base sm:text-lg">
+                  <HeartHandshake className="h-5 w-5 text-primary" />
+                  Help us keep this space supportive
+                </DialogTitle>
+                <DialogDescription className="text-sm leading-relaxed">
+                  Thanks for looking out for the community. Reports are reviewed with care.
+                  {postAuthor ? ` You are reporting a post by ${postAuthor}.` : ""}
+                </DialogDescription>
+              </DialogHeader>
+            </div>
+
+            <div className="p-6 space-y-5">
+              <div className="space-y-3">
+                <p className="text-sm font-medium text-foreground">
+                  What feels concerning?
+                </p>
+                <RadioGroup
+                  value={reason}
+                  onValueChange={(value) => setReason(value as ReportReason)}
+                  className="space-y-2"
+                >
+                  {REPORT_REASONS.map((item) => (
+                    <Label
+                      key={item.value}
+                      htmlFor={`reason-${item.value}`}
+                      className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/70 bg-background p-3 transition-colors hover:bg-muted/40"
+                    >
+                      <RadioGroupItem
+                        id={`reason-${item.value}`}
+                        value={item.value}
+                        className="mt-0.5"
+                      />
+                      <span className="space-y-1">
+                        <span className="block text-sm font-medium text-foreground">
+                          {item.label}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          {item.helper}
+                        </span>
+                      </span>
+                    </Label>
+                  ))}
+                </RadioGroup>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="report-details" className="text-sm font-medium">
+                  Optional details
+                </Label>
+                <Textarea
+                  id="report-details"
+                  value={details}
+                  onChange={(e) => setDetails(e.target.value)}
+                  placeholder="Share anything that might help the moderator review this gently and fairly."
+                  className="min-h-[90px] rounded-xl"
+                />
+                <p className="text-xs text-muted-foreground">
+                  You do not need to explain everything. A short note is enough.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter className="border-t border-border/60 bg-muted/30 px-6 py-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+                disabled={submitting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="calm"
+                onClick={handleSubmit}
+                disabled={!reason || submitting}
+              >
+                {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Submit report"}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <div className="p-6 sm:p-7 text-center space-y-4">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/15">
+              <ShieldCheck className="h-6 w-6 text-primary" />
+            </div>
+            <div className="space-y-2">
+              <h3 className="text-lg font-semibold text-foreground">
+                Thank you for speaking up
+              </h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Your report was sent successfully. Our team will review it thoughtfully to
+                help keep SafeSpace respectful and supportive.
+              </p>
+            </div>
+            <Button type="button" variant="calm" onClick={() => setOpen(false)}>
+              Done
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default PostReportFlow;

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -7,8 +7,17 @@ import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { useAuth } from "@/hooks/useAuth";
 import { useDiscreetMode } from "@/hooks/useDiscreetMode";
+import { useToast } from "@/hooks/use-toast";
 import { type ForumPost } from "@/hooks/useCommunityPosts";
 import { CommunityForumProvider, useCommunityForum } from "@/context/communityForumContext";
+import { PostReportFlow } from "@/components/forum/PostReportFlow";
+import {
+  createComment,
+  listCommentsByPost,
+  type CommunityCommentRow,
+} from "@/services/communityCommentsService";
+import { moderateContent } from "@/services/moderationService";
+import { sanitizeText } from "@/lib/sanitize";
 import {
   Users,
   MessageCircle,
@@ -159,7 +168,9 @@ function ForumModals() {
                   <div>
                     <p className="font-medium">Post anonymously</p>
                     <p className="text-sm text-muted-foreground">
-                      Your identity will be hidden
+                      {postAnonymously
+                        ? "Anonymous ON — your name will be hidden."
+                        : "Anonymous OFF — your display name will be shown."}
                     </p>
                   </div>
                 </div>
@@ -167,6 +178,22 @@ function ForumModals() {
                   checked={postAnonymously}
                   onCheckedChange={setPostAnonymously}
                 />
+              </div>
+
+              <div className="rounded-xl border border-border/70 bg-background/80 p-3">
+                <p className="text-sm font-medium text-foreground">
+                  Posting as: {postAnonymously ? "Anonymous" : "Your display name"}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  You can change this for each post. Discreet mode only changes wording style.
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-primary/20 bg-primary/5 p-3">
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  Privacy in community: anonymous posting hides your name on this post, while profile
+                  privacy settings apply to your account surfaces elsewhere in the app.
+                </p>
               </div>
 
               <div className="flex flex-col-reverse gap-3 sm:flex-row">
@@ -429,6 +456,20 @@ export function CommunityThreadList() {
     toggleLike,
   } = useCommunityForum();
   const { discreetMode } = useDiscreetMode();
+  const { toast } = useToast();
+
+  const handleSubmitReport = async (payload: {
+    postId: string;
+    reason: "inappropriate-language" | "harassment" | "spam" | "crisis-content" | "other";
+    details?: string;
+  }) => {
+    // Temporary handoff stub until report backend endpoint is wired.
+    console.info("[report-post] submitted", payload);
+    toast({
+      title: "Report sent",
+      description: "Thank you for helping us keep this space supportive.",
+    });
+  };
 
   const filtered = useMemo(
     () => posts.filter((p) => postMatchesTopic(p, topicId)),
@@ -574,7 +615,12 @@ export function CommunityThreadList() {
                               </p>
                             </div>
                           </div>
-                          <div className="flex items-center gap-4 text-muted-foreground">
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <PostReportFlow
+                              postId={post.id}
+                              postAuthor={post.author}
+                              onSubmitReport={handleSubmitReport}
+                            />
                             <button
                               type="button"
                               className={`flex items-center gap-1 text-sm transition-colors ${
@@ -633,9 +679,28 @@ export function CommunityPostDetail() {
     refetchPosts,
     fetchPostById,
   } = useCommunityForum();
+  const { toast } = useToast();
 
   const [fetched, setFetched] = useState<ForumPost | null>(null);
   const [fetchingOne, setFetchingOne] = useState(false);
+  const [comments, setComments] = useState<CommunityCommentRow[]>([]);
+  const [loadingComments, setLoadingComments] = useState(false);
+  const [commentText, setCommentText] = useState("");
+  const [commentAnonymously, setCommentAnonymously] = useState(true);
+  const [submittingComment, setSubmittingComment] = useState(false);
+
+  const handleSubmitReport = async (payload: {
+    postId: string;
+    reason: "inappropriate-language" | "harassment" | "spam" | "crisis-content" | "other";
+    details?: string;
+  }) => {
+    // Temporary handoff stub until report backend endpoint is wired.
+    console.info("[report-post] submitted", payload);
+    toast({
+      title: "Report sent",
+      description: "Thank you for helping us keep this space supportive.",
+    });
+  };
 
   const fromList = postId ? posts.find((p) => p.id === postId) : undefined;
   const post = fromList ?? fetched;
@@ -670,6 +735,33 @@ export function CommunityPostDetail() {
     };
   }, [fetchPostById, fromList, postId]);
 
+  useEffect(() => {
+    if (!postId) return;
+    let cancelled = false;
+    const loadComments = async () => {
+      setLoadingComments(true);
+      try {
+        const data = await listCommentsByPost(postId);
+        if (!cancelled) setComments(data);
+      } catch (error) {
+        console.error("Error loading comments:", error);
+        if (!cancelled) {
+          toast({
+            title: "Couldn't load replies",
+            description: "Please try again in a moment.",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (!cancelled) setLoadingComments(false);
+      }
+    };
+    loadComments();
+    return () => {
+      cancelled = true;
+    };
+  }, [postId, toast]);
+
   if (!postId) {
     return null;
   }
@@ -702,6 +794,56 @@ export function CommunityPostDetail() {
     : post.content;
 
   const topicForBack = topicSlugForBack(post);
+  const handleSubmitComment = async () => {
+    const trimmed = commentText.trim();
+    if (!trimmed || !postId || !user) return;
+    if (trimmed.length > 1000) {
+      toast({
+        title: "Reply is too long",
+        description: "Please keep replies under 1000 characters.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setSubmittingComment(true);
+    try {
+      const moderation = await moderateContent(trimmed);
+      if (!moderation.clean) {
+        const categories = Array.from(new Set(moderation.flagged.map((f) => f.category)));
+        toast({
+          title: "Reply blocked by moderation",
+          description: `Please revise your reply. Flagged categories: ${categories.join(", ")}.`,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const inserted = await createComment({
+        postId,
+        userId: user.id,
+        authorName: user.user_metadata?.display_name || "User",
+        isAnonymous: commentAnonymously,
+        content: trimmed,
+      });
+
+      setComments((prev) => [...prev, inserted]);
+      setCommentText("");
+      toast({
+        title: "Reply posted",
+        description: "Your reply is now visible in this thread.",
+      });
+    } catch (error) {
+      console.error("Error creating reply:", error);
+      toast({
+        title: "Couldn't post reply",
+        description: "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmittingComment(false);
+    }
+  };
 
   return (
     <article className="space-y-5">
@@ -765,7 +907,12 @@ export function CommunityPostDetail() {
           )}
 
           <div className="flex flex-col gap-4 border-t border-border/50 pt-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-6">
+            <div className="flex flex-wrap items-center gap-4">
+              <PostReportFlow
+                postId={post.id}
+                postAuthor={post.author}
+                onSubmitReport={handleSubmitReport}
+              />
               <button
                 type="button"
                 onClick={async () => {
@@ -788,36 +935,104 @@ export function CommunityPostDetail() {
               </button>
               <span className="flex items-center gap-2 text-sm text-muted-foreground">
                 <MessageCircle className="h-5 w-5" />
-                Replies coming soon
+                {comments.length} {comments.length === 1 ? "reply" : "replies"}
               </span>
             </div>
 
             {user && post.userId === user.id && (
-              <div className="flex gap-2">
+              <div className="flex flex-wrap gap-2">
                 <Button
                   variant="outline"
                   size="sm"
-                  className="rounded-xl"
+                  className="rounded-xl px-2 sm:px-3"
                   onClick={() => startEditing(post)}
+                  aria-label="Edit post"
                 >
                   <Pencil className="h-4 w-4" />
-                  Edit
+                  <span className="hidden sm:inline">Edit</span>
                 </Button>
                 <Button
                   variant="outline"
                   size="sm"
-                  className="rounded-xl text-destructive hover:text-destructive"
+                  className="rounded-xl px-2 sm:px-3 text-destructive hover:text-destructive"
                   onClick={async () => {
                     await deletePost(post.id);
                     navigate("/community");
                     await refetchPosts();
                   }}
+                  aria-label="Delete post"
                 >
                   <Trash2 className="h-4 w-4" />
-                  Delete
+                  <span className="hidden sm:inline">Delete</span>
                 </Button>
               </div>
             )}
+          </div>
+
+          <div className="space-y-4 border-t border-border/50 pt-4">
+            <h2 className="text-sm font-semibold text-foreground">Replies</h2>
+
+            {loadingComments ? (
+              <p className="text-sm text-muted-foreground">Loading replies...</p>
+            ) : comments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No replies yet. You can start the conversation gently.
+              </p>
+            ) : (
+              <ul className="space-y-3">
+                {comments.map((comment) => (
+                  <li key={comment.id} className="rounded-xl border border-border/60 bg-muted/20 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        {comment.is_anonymous
+                          ? "Anonymous"
+                          : sanitizeText(comment.author_name || "Community member")}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(comment.created_at).toLocaleString()}
+                      </p>
+                    </div>
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-foreground">
+                      {sanitizeText(comment.content)}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="space-y-3 rounded-xl border border-border/60 bg-background p-3">
+              <Textarea
+                value={commentText}
+                onChange={(e) => setCommentText(e.target.value)}
+                placeholder="Write a supportive reply..."
+                className="min-h-[90px]"
+                maxLength={1000}
+              />
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={commentAnonymously}
+                    onCheckedChange={setCommentAnonymously}
+                    id="comment-anonymous-toggle"
+                  />
+                  <label
+                    htmlFor="comment-anonymous-toggle"
+                    className="text-xs text-muted-foreground"
+                  >
+                    Reply anonymously
+                  </label>
+                </div>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="calm"
+                  onClick={handleSubmitComment}
+                  disabled={!commentText.trim() || submittingComment}
+                >
+                  {submittingComment ? <Loader2 className="h-4 w-4 animate-spin" /> : "Post reply"}
+                </Button>
+              </div>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -202,8 +202,10 @@ const Profile = () => {
             <div className="flex items-center gap-3">
               <EyeOff className="h-5 w-5 text-muted-foreground" />
               <div>
-                <p className="font-medium">Anonymous Mode</p>
-                <p className="text-sm text-muted-foreground">Hide your identity</p>
+                <p className="font-medium">Anonymous Mode (profile visibility)</p>
+                <p className="text-sm text-muted-foreground">
+                  Hides your identity on profile surfaces. Community post anonymity is set per post.
+                </p>
               </div>
             </div>
             <Switch checked={isAnonymous} onCheckedChange={handleAnonymousToggle} />
@@ -227,7 +229,9 @@ const Profile = () => {
               <Moon className="h-5 w-5 text-muted-foreground" />
               <div>
                 <p className="font-medium">Discreet Mode</p>
-                <p className="text-sm text-muted-foreground">Use more neutral language in the app</p>
+                <p className="text-sm text-muted-foreground">
+                  Uses more neutral language in the app. It does not change your post anonymity.
+                </p>
               </div>
             </div>
             <Switch checked={privacyMode} onCheckedChange={handlePrivacyToggle} />

--- a/src/services/communityCommentsService.ts
+++ b/src/services/communityCommentsService.ts
@@ -1,0 +1,45 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface CommunityCommentRow {
+  id: string;
+  post_id: string;
+  user_id: string;
+  author_name: string | null;
+  is_anonymous: boolean;
+  content: string;
+  created_at: string;
+}
+
+export async function listCommentsByPost(postId: string): Promise<CommunityCommentRow[]> {
+  const { data, error } = await supabase
+    .from("community_post_comments")
+    .select("*")
+    .eq("post_id", postId)
+    .order("created_at", { ascending: true });
+
+  if (error) throw error;
+  return (data as CommunityCommentRow[]) ?? [];
+}
+
+export async function createComment(input: {
+  postId: string;
+  userId: string;
+  authorName: string | null;
+  isAnonymous: boolean;
+  content: string;
+}): Promise<CommunityCommentRow> {
+  const { data, error } = await supabase
+    .from("community_post_comments")
+    .insert({
+      post_id: input.postId,
+      user_id: input.userId,
+      author_name: input.authorName,
+      is_anonymous: input.isAnonymous,
+      content: input.content,
+    })
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return data as CommunityCommentRow;
+}

--- a/supabase/migrations/20260414113000_create_community_post_comments.sql
+++ b/supabase/migrations/20260414113000_create_community_post_comments.sql
@@ -1,0 +1,39 @@
+-- Comments for community discussion posts
+CREATE TABLE public.community_post_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id uuid NOT NULL REFERENCES public.community_posts(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  author_name text,
+  is_anonymous boolean NOT NULL DEFAULT true,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.community_post_comments ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read comments
+CREATE POLICY "Comments are viewable by everyone"
+ON public.community_post_comments
+FOR SELECT
+USING (true);
+
+-- Authenticated users can create their own comments
+CREATE POLICY "Users can create their own comments"
+ON public.community_post_comments
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+-- Authenticated users can update their own comments
+CREATE POLICY "Users can update their own comments"
+ON public.community_post_comments
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Authenticated users can delete their own comments
+CREATE POLICY "Users can delete their own comments"
+ON public.community_post_comments
+FOR DELETE
+TO authenticated
+USING (auth.uid() = user_id);


### PR DESCRIPTION
**Description:**
This PR completes the community UX and interaction work for F2.2, F2.3, and F2.7, covering supportive moderation and reporting, filtered discussion navigation, anonymity clarity, and post comments end-to-end.

**Changes Made:**

*F2.2 — Content reporting, censorship feedback, topic filtering*
- Created `src/components/forum/PostReportFlow.tsx`: standalone reporting component with subtle report trigger, reason selection (inappropriate language, harassment, spam, crisis content, other), optional details field, and supportive confirmation state
- Wired `PostReportFlow` into thread list post cards and post detail view
- Moderation pre-check behavior now surfaces user-friendly blocked feedback in posting, messaging, and journal flows with supportive, non-shaming tone
- Section-level community navigation and per-topic thread filtering retained and clarified

*F2.3 — Small filtered discussion spaces and anonymity toggle*
- Filtered community section entry points and per-section thread views confirmed clear and navigable
- Composer now shows explicit ON/OFF anonymity guidance and a "Posting as…" pre-submit summary
- Added concise privacy explainer in composer distinguishing profile visibility settings, per-post anonymity, and discreet mode behavior
- Updated profile privacy copy in `src/pages/Profile.tsx` for the same distinction
- Removed redundant Anonymous/Named badges from posts to reduce UI noise

*F2.7 — Comments on discussion posts*
- Added comment input on post detail with required content validation and length limit enforcement
- Supports optional anonymous reply toggle
- Created `src/services/communityCommentsService.ts` for comment data operations
- Created migration `20260414113000_create_community_post_comments.sql` adding `community_post_comments` table with `post_id` FK and RLS policies for read/create/update/delete with ownership rules
- Comments loaded by post id and rendered in thread detail view
- Reply count displayed in post detail action bar

**Files Added/Updated:**
- Added: `src/components/forum/PostReportFlow.tsx`, `src/services/communityCommentsService.ts`, `supabase/migrations/20260414113000_create_community_post_comments.sql`
- Updated: `src/pages/Community.tsx`, `src/pages/Profile.tsx`

**Testing:**
- Report trigger appears on list and detail posts, modal submits, and confirmation displays correctly
- Topic filters and section navigation update thread lists correctly
- Composer anonymity guidance updates with toggle and shows correct posting summary
- Comment submission blocks empty and oversized input, persists to DB, displays under correct post, and updates reply count
- Profile privacy text accurately reflects current behavior

**Notes:**
- F2.1 (Discussion Forum UI) was reviewed and confirmed already completed. No changes required.
- Report submission is currently wired to a temporary stub : backend `content_reports` table and endpoint implementation is a follow-up
- Language and visuals remain calm and supportive throughout for social anxiety users
- Reporting and moderation feedback is framed with care, avoiding language that shames or alarms users

**Closes:** #F2.1, #F2.2, #F2.3, #F2.7
