### PR TITLE
Messaging: send logic, persistence + realtime updates (F8.4–F8.6)

### DIFF
--- a/src/components/MessageThread.tsx
+++ b/src/components/MessageThread.tsx
@@ -42,7 +42,7 @@ export function MessageThread({ friendshipId, friendName, myProfileId, onClose }
     loadMessages();
 
     const unsubscribe = subscribeToMessages(friendshipId, (message) => {
-      setMessages((prev) => [...prev, message]);
+      setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
     });
 
     return () => {
@@ -73,7 +73,8 @@ export function MessageThread({ friendshipId, friendName, myProfileId, onClose }
         return;
       }
 
-      await sendMessage(friendshipId, myProfileId, trimmed);
+      const inserted = await sendMessage(friendshipId, myProfileId, trimmed);
+      setMessages((prev) => (prev.some((m) => m.id === inserted.id) ? prev : [...prev, inserted]));
       setNewMessage("");
     } catch (error) {
       console.error("Error sending message:", error);

--- a/src/services/messagesService.ts
+++ b/src/services/messagesService.ts
@@ -2,6 +2,7 @@ import { supabase } from "@/integrations/supabase/client";
 
 export interface Message {
   id: string;
+  friendship_id: string;
   content: string;
   sender_profile_id: string;
   created_at: string;
@@ -18,14 +19,23 @@ export async function listMessages(friendshipId: string): Promise<Message[]> {
   return (data as Message[]) ?? [];
 }
 
-export async function sendMessage(friendshipId: string, senderProfileId: string, content: string) {
-  const { error } = await supabase.from("messages").insert({
-    friendship_id: friendshipId,
-    sender_profile_id: senderProfileId,
-    content,
-  });
+export async function sendMessage(
+  friendshipId: string,
+  senderProfileId: string,
+  content: string
+): Promise<Message> {
+  const { data, error } = await supabase
+    .from("messages")
+    .insert({
+      friendship_id: friendshipId,
+      sender_profile_id: senderProfileId,
+      content,
+    })
+    .select("*")
+    .single();
 
   if (error) throw error;
+  return data as Message;
 }
 
 export function subscribeToMessages(

--- a/supabase/migrations/20260416113000_add_message_indexes.sql
+++ b/supabase/migrations/20260416113000_add_message_indexes.sql
@@ -1,0 +1,10 @@
+-- Add indexes to keep message queries fast as history grows.
+-- Primary access pattern: list messages for a friendship ordered by created_at.
+
+CREATE INDEX IF NOT EXISTS messages_friendship_id_created_at_idx
+ON public.messages (friendship_id, created_at);
+
+-- Helpful for user-centric message queries and moderation/admin tooling.
+CREATE INDEX IF NOT EXISTS messages_sender_profile_id_created_at_idx
+ON public.messages (sender_profile_id, created_at);
+

--- a/supabase/migrations/20260416114500_enable_realtime_for_messages.sql
+++ b/supabase/migrations/20260416114500_enable_realtime_for_messages.sql
@@ -1,0 +1,5 @@
+-- Ensure Supabase Realtime delivers INSERT events for messages.
+-- Without this, `postgres_changes` subscriptions may not receive updates.
+
+ALTER PUBLICATION supabase_realtime ADD TABLE public.messages;
+


### PR DESCRIPTION
Summary
F8.4 Send Message Logic: Wire the friends-page conversation input to persist messages, validate non-empty submissions, clear the input after send, and ensure the new message appears in the thread immediately (even if realtime delivery is delayed).
F8.5 Messaging DB Support: Use friendships as the conversation container, store messages in messages, enforce FK relationships and RLS for secure access, and add indexes for scalable per-conversation reads.
F8.6 Real-Time Message Updates: Subscribe to messages inserts via Supabase Realtime so active conversations update automatically, plus a migration to ensure messages is included in the realtime publication.

Changes included
UI / app
MessageThread subscribes to new messages and appends them to the thread with dedupe.
Sending returns the inserted message and appends immediately; input clears on success.
Database
messages table uses FKs to friendships and profiles.
RLS policies restrict read/write to participants in accepted friendships.
Added indexes for messages(friendship_id, created_at) and messages(sender_profile_id, created_at).
Enabled Realtime publication for public.messages.
Files / migrations
src/components/MessageThread.tsx
src/services/messagesService.ts
supabase/migrations/20260416113000_add_message_indexes.sql
supabase/migrations/20260416114500_enable_realtime_for_messages.sql

Test plan
Send message: From Friends page → open a friend chat → send a message → confirm it appears immediately and input clears.
Persistence: Reload the page → open the same chat → confirm the message is still present.
Realtime: Open the same chat in two sessions/browsers → send from one → confirm the other updates without refresh.
Access control: Confirm non-friends / non-participants can’t read or insert messages (RLS).